### PR TITLE
inclusion of canonical, description and GA tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ yarn-error.log
 .idea/
 .DS_Store
 docs/
+.hugo_build.lock

--- a/config.toml
+++ b/config.toml
@@ -48,7 +48,7 @@ resampleFilter = "CatmullRom"
 [services]
 [services.googleAnalytics]
 # Comment out the next line to disable GA tracking. Also disables the feature described in [params.ui.feedback].
-id = "UA-00000000-0"
+id = "UA-163714585-1"
 
 # Language configuration
 

--- a/themes/ritchie/assets/vendor/bootstrap/site/_includes/header.html
+++ b/themes/ritchie/assets/vendor/bootstrap/site/_includes/header.html
@@ -15,7 +15,7 @@
   {%- endif -%}
 </title>
 
-<link rel="canonical" href="{{ site.url | append: page.url }}">
+<link rel="canonical" href="https://docs.ritchiecli.io/">
 
 {% include stylesheet.html %}
 {% include favicons.html %}

--- a/themes/ritchie/assets/vendor/bootstrap/site/_layouts/examples.html
+++ b/themes/ritchie/assets/vendor/bootstrap/site/_layouts/examples.html
@@ -8,7 +8,7 @@
     <meta name="generator" content="Jekyll v{{ jekyll.version }}">
     <title>{{ page.title | smartify }} · {{ site.title | smartify }}</title>
 
-    <link rel="canonical" href="{{ site.url | append: page.url }}">
+    <link rel="canonical" href="https://docs.ritchiecli.io/">
 
     {% include stylesheet.html %}
     {% include favicons.html %}

--- a/themes/ritchie/layouts/partials/head.html
+++ b/themes/ritchie/layouts/partials/head.html
@@ -6,6 +6,12 @@
 {{ else }}
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 {{ end }}
+{{ if .Page.Description }}
+<meta name="description" content="Ritchie is an open source framework that allows you to create, store and share any kind of automations, executing them through command lines, to run operations or start workflows.">
+{{ else }}
+{{ $desc := (.Page.Content | safeHTML | truncate 150) }}
+<meta name="description" content="Ritchie is an open source framework that allows you to create, store and share any kind of automations, executing them through command lines, to run operations or start workflows.">
+{{ end }}
 {{ range .AlternativeOutputFormats -}}
 <link rel="{{ .Rel }}" type="{{ .MediaType.Type }}" href="{{ .Permalink | safeURL }}">
 {{ end -}}
@@ -19,17 +25,16 @@
 {{ template "_internal/google_analytics_async.html" . }}
 {{ end }}
 {{ partialCached "head-css.html" . "asdf" }}
-<script
-  src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.5.1/jquery.min.js"
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.5.1/jquery.min.js"
   integrity="sha512-bLT0Qm9VnAYZDflyKcBaQ2gg0hSYNQrJ8RilYldYQ1FxQYoCLtUjuuRuZo+fjqhx/qtq/1itJ0C2ejDxltZVFg=="
   crossorigin="anonymous"></script>
 {{ if .Site.Params.offlineSearch }}
-<script
-  src="https://unpkg.com/lunr@2.3.8/lunr.min.js"
-  integrity="sha384-vRQ9bDyE0Wnu+lMfm57BlYLO0/XauFuKpVsZPs7KEDwYKktWi5+Kz3MP8++DFlRY"
-  crossorigin="anonymous"></script>
+<script src="https://unpkg.com/lunr@2.3.8/lunr.min.js"
+  integrity="sha384-vRQ9bDyE0Wnu+lMfm57BlYLO0/XauFuKpVsZPs7KEDwYKktWi5+Kz3MP8++DFlRY" crossorigin="anonymous"></script>
 {{end}}
-<script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.21/lodash.min.js" integrity="sha512-WFN04846sdKMIP5LKNphMaWzU7YpMyCU245etK3g/2ARYbPK9Ub18eG+ljU96qKRCWh+quCY7yefSmlkQw1ANQ==" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.21/lodash.min.js"
+  integrity="sha512-WFN04846sdKMIP5LKNphMaWzU7YpMyCU245etK3g/2ARYbPK9Ub18eG+ljU96qKRCWh+quCY7yefSmlkQw1ANQ=="
+  crossorigin="anonymous"></script>
 {{ with .Site.Params.prism_syntax_highlighting }}
 <!-- stylesheet for Prism -->
 <link rel="stylesheet" href="/css/prism.css" />

--- a/themes/ritchie/userguide/config.toml
+++ b/themes/ritchie/userguide/config.toml
@@ -65,7 +65,7 @@ anchor = "smart"
 [services]
 [services.googleAnalytics]
 # Comment out the next line to disable GA tracking. Also disables the feature described in [params.ui.feedback].
-id = "UA-00000000-0"
+id = "UA-163714585-1"
 
 # Language configuration
 


### PR DESCRIPTION
Inclusion of canonical URL and description tags for better SEO. And GA number because docsy isn't reconizing the GTM code for analytics.