### PR TITLE
inclusion of canonical, description and GA tags

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -85,6 +85,7 @@ copyright = "Zup"
 privacy_policy = "https://insights.zup.com.br/politica-privacidade"
 version_path = ""
 logoName = "icons/ritchie.svg"
+gtm_id="GTM-TWPT3CF"
 
 isDocumentationDeprecated = false
 

--- a/config.toml
+++ b/config.toml
@@ -48,7 +48,7 @@ resampleFilter = "CatmullRom"
 [services]
 [services.googleAnalytics]
 # Comment out the next line to disable GA tracking. Also disables the feature described in [params.ui.feedback].
-id = "UA-00000000-0"
+id = "UA-163714585-1"
 
 # Language configuration
 

--- a/themes/ritchie/assets/vendor/bootstrap/site/_includes/header.html
+++ b/themes/ritchie/assets/vendor/bootstrap/site/_includes/header.html
@@ -15,7 +15,7 @@
   {%- endif -%}
 </title>
 
-<link rel="canonical" href="{{ site.url | append: page.url }}">
+<link rel="canonical" href="https://docs.ritchiecli.io/">
 
 {% include stylesheet.html %}
 {% include favicons.html %}

--- a/themes/ritchie/assets/vendor/bootstrap/site/_layouts/examples.html
+++ b/themes/ritchie/assets/vendor/bootstrap/site/_layouts/examples.html
@@ -8,7 +8,7 @@
     <meta name="generator" content="Jekyll v{{ jekyll.version }}">
     <title>{{ page.title | smartify }} · {{ site.title | smartify }}</title>
 
-    <link rel="canonical" href="{{ site.url | append: page.url }}">
+    <link rel="canonical" href="https://docs.ritchiecli.io/">
 
     {% include stylesheet.html %}
     {% include favicons.html %}

--- a/themes/ritchie/config.toml
+++ b/themes/ritchie/config.toml
@@ -9,6 +9,7 @@ time_format_blog = "Monday, January 02, 2006"
 time_format_default = "January 2, 2006"
 # Sections to publish in the main RSS feed.
 rss_sections = ["blog"]
+gtm_id="GTM-TWPT3CF"
 
 
 # For a full list of parameters used in Docsy sites, see:

--- a/themes/ritchie/layouts/partials/head.html
+++ b/themes/ritchie/layouts/partials/head.html
@@ -6,6 +6,12 @@
 {{ else }}
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 {{ end }}
+{{ if .Page.Description }}
+<meta name="description" content="Ritchie is an open source framework that allows you to create, store and share any kind of automations, executing them through command lines, to run operations or start workflows.">
+{{ else }}
+{{ $desc := (.Page.Content | safeHTML | truncate 150) }}
+<meta name="description" content="Ritchie is an open source framework that allows you to create, store and share any kind of automations, executing them through command lines, to run operations or start workflows.">
+{{ end }}
 {{ range .AlternativeOutputFormats -}}
 <link rel="{{ .Rel }}" type="{{ .MediaType.Type }}" href="{{ .Permalink | safeURL }}">
 {{ end -}}

--- a/themes/ritchie/userguide/config.toml
+++ b/themes/ritchie/userguide/config.toml
@@ -92,6 +92,7 @@ weight = 1
 [params]
 copyright = "The Docsy Authors"
 privacy_policy = "https://policies.google.com/privacy"
+gtm_id="GTM-TWPT3CF"
 
 # Menu title if your navbar has a versions selector to access old versions of your site.
 # This menu appears only if you have at least one [params.versions] set.

--- a/themes/ritchie/userguide/config.toml
+++ b/themes/ritchie/userguide/config.toml
@@ -65,7 +65,7 @@ anchor = "smart"
 [services]
 [services.googleAnalytics]
 # Comment out the next line to disable GA tracking. Also disables the feature described in [params.ui.feedback].
-id = "UA-00000000-0"
+id = "UA-163714585-1"
 
 # Language configuration
 


### PR DESCRIPTION
Inclusion of canonical URL and description tags for better SEO. And GA number because docsy isn't reconizing the GTM code for analytics.